### PR TITLE
use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/test/test_rcall.jl
+++ b/test/test_rcall.jl
@@ -5,7 +5,7 @@ using Phylo
 Rinstalled = false
 try
     using RCall
-    include(Pkg.dir("Phylo", "src/rcall.jl"))
+    include(joinpath(dirname(dirname(@__FILE__)), "src/rcall.jl"))
     Rinstalled = true
 catch
     warn("R not installed, skipping RCall testing")


### PR DESCRIPTION
this allows installing and loading the package from elsewhere