### PR TITLE
plotting of AbstractTrees; close #8

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Missings
 IterableTables
 Requires
 DataFrames
+RecipesBase

--- a/src/Phylo.jl
+++ b/src/Phylo.jl
@@ -136,6 +136,9 @@ include("show.jl")
 include("trim.jl")
 export droptips!, keeptips!
 
+# Plot recipes
+#include("plot.jl")
+
 # Path into package
 path(path...; dir::String = "test") = joinpath(@__DIR__, "..", dir, path...)
 

--- a/src/Phylo.jl
+++ b/src/Phylo.jl
@@ -137,7 +137,7 @@ include("trim.jl")
 export droptips!, keeptips!
 
 # Plot recipes
-#include("plot.jl")
+include("plot.jl")
 
 # Path into package
 path(path...; dir::String = "test") = joinpath(@__DIR__, "..", dir, path...)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -4,7 +4,7 @@ using Plots # now necessary for the labels :-(
 
 @recipe function f(tree::Phylo.AbstractTree; treetype = :dendrogram, showtips = true, tipfont = (5,))
 
-    linecolor --> :black
+    #linecolor --> :black
     grid --> false
     framestyle --> :none
     legend --> false

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -47,6 +47,14 @@ struct Fan; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
         seriestype := :path
         markersize := 0
         markershape := :none
+
+        lc = _extend(get(plotattributes, :linecolor, nothing), d.x)
+        lc !== nothing && (linecolor := lc)
+        la = _extend(get(plotattributes, :linealpha, nothing), d.x)
+        la !== nothing && (linealpha := la)
+        lz = _extend(get(plotattributes, :line_z, nothing), d.x)
+        lz !== nothing && (line_z := lz)
+
         d.x, d.y
     end
     if !isempty(d.marker_x)
@@ -66,6 +74,12 @@ end
         markersize := 0
         markershape := :none
         x, y = _circle_transform_segments(d.x, adjust(d.y))
+        lc = _extend(get(plotattributes, :linecolor, nothing), x)
+        lc !== nothing && (linecolor := lc)
+        la = _extend(get(plotattributes, :linealpha, nothing), x)
+        la !== nothing && (linealpha := la)
+        lz = _extend(get(plotattributes, :line_z, nothing), x)
+        lz !== nothing && (line_z := lz)
         x, y
     end
     if !isempty(d.marker_x)
@@ -82,6 +96,16 @@ end
     [],[]
 end
 
+function _extend(tmp, x)
+    tmp isa AbstractVector && abs(length(tmp) - count(isnan, x)) < 2 || return nothing
+    ret = similar(x, eltype(tmp))
+    j = 1 + length(tmp) - count(isnan, x)
+    for i in eachindex(x)
+        ret[i] = tmp[j]
+        isnan(x[i]) && (j += 1)
+    end
+    return ret
+end
 
 leafiter(tree) = nodenamefilter(isleaf, tree)
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -121,6 +121,26 @@ end
 
 leafiter(tree) = nodenamefilter(isleaf, tree)
 
+
+
+function ladderize!(tree::AbstractTree)
+    function loc!(clade::String)
+        if isleaf(tree, clade)
+            return 1
+        end
+
+        sizes = map(loc!, getchildren(tree, clade))
+        node = getnode(tree, clade)
+        node.outbounds .= node.outbounds[sortperm(sizes)]
+        sum(sizes) + 1
+    end
+
+    loc!(first(nodenamefilter(isroot, tree)))
+    tree
+end
+
+
+
 function _findxy(tree::Phylo.AbstractTree)
 
     # two convenience recursive functions using captured variables

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -199,3 +199,19 @@ function _circle_transform_segments(xs, ys)
     end
     retx, rety
 end
+
+
+# a function to update a value successively from the root to the tips
+function map_depthfirst(FUN, start, tree, eltype = nothing)
+    root = first(nodenamefilter(isroot, tree))
+    eltype === nothing && (eltype = typeof(FUN(start, root)))
+    ret = Vector{eltype}()
+    function local!(val, node)
+        push!(ret, val)
+        for ch in getchildren(tree, node)
+            local!(FUN(val, node), ch)
+        end
+    end
+    local!(start, root)
+    ret
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -73,10 +73,14 @@ end
 
 @recipe function f(d::Fan)
     adjust(y) = 2pi*y / (length(d.tipannotations) + 1)
+
+    sa = get(plotattributes, :series_annotations, nothing)
     @series begin
         seriestype := :path
         markersize := 0
         markershape := :none
+        series_annotations := nothing
+
         x, y = _circle_transform_segments(d.x, adjust(d.y))
         lc = _extend(get(plotattributes, :linecolor, nothing), x)
         lc !== nothing && (linecolor := lc)
@@ -86,9 +90,10 @@ end
         lz !== nothing && (line_z := lz)
         x, y
     end
-    if !isempty(d.marker_x)
+    if !isempty(d.marker_x) || sa !== nothing
         @series begin
             seriestype := :scatter
+            a !== nothing && (series_annotations := sa)
             _xcirc.(adjust(d.marker_y), d.marker_x), _ycirc.(adjust(d.marker_y), d.marker_x)
         end
     end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -67,7 +67,7 @@ struct Fan; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
             d.marker_x, d.marker_y
         end
     end
-    d.showtips && (annotations := map(x -> (x[1], x[2], text(x[3], :left, d.tipfont...)), d.tipannotations))
+    d.showtips && (annotations := map(x -> (x[1], x[2], (x[3], :left, d.tipfont...)), d.tipannotations))
     [],[]
 end
 
@@ -102,7 +102,7 @@ end
     if d.showtips
         xlim --> (1.3 .* (-mx, mx))
         ylim --> (1.3 .* (-mx, mx))
-        annotations := map(x -> (_tocirc(x[1], adjust(x[2]))..., text(x[3], :left,
+        annotations := map(x -> (_tocirc(x[1], adjust(x[2]))..., (x[3], :left,
             rad2deg(adjust(x[2])), d.tipfont...)), d.tipannotations)
     end
     [],[]

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,6 +1,4 @@
 using RecipesBase
-using Phylo
-using Plots # now necessary for the labels :-(
 
 @recipe function f(tree::Phylo.AbstractTree; treetype = :dendrogram, showtips = true, tipfont = (5,))
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,170 @@
+using RecipesBase
+using Phylo
+using Plots # now necessary for the labels :-(
+
+@recipe function f(tree::Phylo.AbstractTree; treetype = :dendrogram, showtips = true, tipfont = (5,))
+
+    linecolor --> :black
+    grid --> false
+    framestyle --> :none
+    legend --> false
+    colorbar --> true
+    size --> (1000, 1000)
+
+    d, h, n = _findxy(tree)
+    adj = 0.03maximum(values(d))
+    tipannotations = map(x->(d[x] + adj, h[x], x), leafiter(tree))
+
+    x, y = Float64[], Float64[]
+    for node ∈ n
+        if hasinbound(tree, node)
+            push!(x, d[getparent(tree, node)], d[getparent(tree, node)], d[node], NaN)
+            push!(y, h[getparent(tree, node)], h[node], h[node], NaN)
+        end
+    end
+
+    marker_x, marker_y = Float64[], Float64[]
+    if any(x->occursin(r"marker", String(x)), keys(plotattributes))
+        f = nodenamefilter(!isleaf, tree)
+        append!(marker_x, getindex.(Ref(d), f))
+        append!(marker_y, getindex.(Ref(h), f))
+    end
+
+    if treetype == :dendrogram
+        Dendrogram(x, y, tipannotations, marker_x, marker_y, showtips, tipfont)
+    elseif treetype == :fan
+        Fan(x, y, tipannotations, marker_x, marker_y, showtips, tipfont)
+    else
+        throw(ArgumentError("Unsupported `treetype`; valid values are `:dendrogram` or `:fan`"))
+    end
+end
+
+struct Dendrogram; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
+struct Fan; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
+
+@recipe function f(d::Dendrogram)
+    @series begin
+        seriestype := :path
+        markersize := 0
+        markershape := :none
+        d.x, d.y
+    end
+    if !isempty(d.marker_x)
+        @series begin
+            seriestype := :scatter
+            d.marker_x, d.marker_y
+        end
+    end
+    d.showtips && (annotations := map(x -> (x[1], x[2], text(x[3], :left, d.tipfont...)), d.tipannotations))
+    [],[]
+end
+
+@recipe function f(d::Fan)
+    adjust(y) = 2pi*y / (length(d.tipannotations) + 1)
+    @series begin
+        seriestype := :path
+        markersize := 0
+        markershape := :none
+        x, y = _circle_transform_segments(d.x, adjust(d.y))
+        x, y
+    end
+    if !isempty(d.marker_x)
+        @series begin
+            seriestype := :scatter
+            _xcirc.(adjust(d.marker_y), d.marker_x), _ycirc.(adjust(d.marker_y), d.marker_x)
+        end
+    end
+    aspect_ratio := 1
+    mx = maximum(filter(isfinite, d.x))
+    xlim --> (1.3 .* (-mx, mx))
+    ylim --> (1.3 .* (-mx, mx))
+    d.showtips && (annotations := map(x -> (_tocirc(x[1], adjust(x[2]))..., text(x[3], :left, rad2deg(adjust(x[2])), d.tipfont...)), d.tipannotations))
+    [],[]
+end
+
+
+leafiter(tree) = nodenamefilter(isleaf, tree)
+
+function _findxy(tree::Phylo.AbstractTree)
+
+    # two convenience recursive functions using captured variables
+    function findheights!(clade::String)
+        if !in(clade, keys(height))
+            for subclade in getchildren(tree, clade)
+                findheights!(subclade)
+            end
+        end
+        if !isleaf(tree, clade)
+            ch_heights = [height[child] for child in getchildren(tree, clade)]
+            height[clade] = (maximum(ch_heights) + minimum(ch_heights)) / 2.
+        end
+    end
+
+    function finddepths!(clade::String)
+        push!(names, clade)
+        if hasinbound(tree, clade)
+            depth[clade] = depth[getparent(tree, clade)] + getbranch(tree, getinbound(tree, clade)).length
+        end
+        for ch in getchildren(tree, clade)
+            finddepths!(ch)
+        end
+    end
+
+    root = first(nodenamefilter(isroot, tree))
+    height = Dict(tip => float(i) for (i, tip) in enumerate(leafiter(tree)))
+    sizehint!(height, length(nodeiter(tree)))
+    findheights!(root)
+
+    depth = Dict{String, Float64}(root => 0)
+    names = String[]
+    sizehint!(depth, length(nodeiter(tree)))
+    sizehint!(names, length(nodeiter(tree)))
+    finddepths!(root)
+
+    depth, height, names
+end
+
+function _find_tips(depth, height, tree)
+    x, y, l = Float64[], Float64[], String[]
+    for k in keys(depth)
+        if isleaf(tree, k)
+            push!(x, depth[k])
+            push!(y, height[k])
+            push!(l, k)
+        end
+    end
+    x, y, l
+end
+
+function _p_circ(start_θ, end_θ, r=1)
+    steps = range(start_θ, stop=end_θ, length = 1+ceil(Int, 60abs(end_θ - start_θ)))
+    retx = Array{Float64}(undef, length(steps))
+    rety = similar(retx)
+    for u in eachindex(steps)
+        retx[u] = _xcirc(steps[u], r)
+        rety[u] = _ycirc(steps[u], r)
+    end
+    retx, rety
+end
+
+_xcirc(x, r) = r*cos(x)
+_ycirc(y, r) = r*sin(y)
+_tocirc(x, y) = _xcirc(y, x), _ycirc(y, x)
+
+function _circle_transform_segments(xs, ys)
+    retx, rety = Float64[], Float64[]
+    function _transform_seg(_x, _y)
+        tmpx, tmpy = _p_circ(_y[1], _y[2], _x[1])
+        append!(retx, tmpx)
+        append!(rety, tmpy)
+        push!(retx, _xcirc(_y[3], _x[3]), NaN)
+        push!(rety, _ycirc(_y[3], _x[3]), NaN)
+    end
+    i = 1
+    while !(i === nothing) && i < length(xs)
+        j = findnext(isnan, xs, i) - 1
+        _transform_seg(view(xs,i:j), view(ys, i:j))
+        i = j + 2
+    end
+    retx, rety
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -43,10 +43,13 @@ struct Dendrogram; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; 
 struct Fan; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
 
 @recipe function f(d::Dendrogram)
+
+    sa = get(plotattributes, :series_annotations, nothing)
     @series begin
         seriestype := :path
         markersize := 0
         markershape := :none
+        series_annotations := nothing
 
         lc = _extend(get(plotattributes, :linecolor, nothing), d.x)
         lc !== nothing && (linecolor := lc)
@@ -57,9 +60,10 @@ struct Fan; x; y; tipannotations; marker_x; marker_y; showtips; tipfont; end
 
         d.x, d.y
     end
-    if !isempty(d.marker_x)
+    if !isempty(d.marker_x) || sa !== nothing
         @series begin
             seriestype := :scatter
+            sa !== nothing && (series_annotations := sa)
             d.marker_x, d.marker_y
         end
     end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -123,7 +123,7 @@ leafiter(tree) = nodenamefilter(isleaf, tree)
 
 
 
-function ladderize!(tree::AbstractTree)
+function Base.sort!(tree::AbstractTree)
     function loc!(clade::String)
         if isleaf(tree, clade)
             return 1

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -90,9 +90,12 @@ end
     end
     aspect_ratio := 1
     mx = maximum(filter(isfinite, d.x))
-    xlim --> (1.3 .* (-mx, mx))
-    ylim --> (1.3 .* (-mx, mx))
-    d.showtips && (annotations := map(x -> (_tocirc(x[1], adjust(x[2]))..., text(x[3], :left, rad2deg(adjust(x[2])), d.tipfont...)), d.tipannotations))
+    if d.showtips
+        xlim --> (1.3 .* (-mx, mx))
+        ylim --> (1.3 .* (-mx, mx))
+        annotations := map(x -> (_tocirc(x[1], adjust(x[2]))..., text(x[3], :left,
+            rad2deg(adjust(x[2])), d.tipfont...)), d.tipannotations)
+    end
     [],[]
 end
 


### PR DESCRIPTION
### Do not merge yet

This PR awaits some improvements on the text formatting side in Plots, which may be a little while. However, I just wanted to show the progress and ideas, and harvest feedback. Feedback on anything - the interface, commands, defaults, line widths, font sizes, spacing etc very welcome. This is a crucial part of getting it right.

I've put some general considerations in #14, as there was things that was difficult for me to learn and adapt to.

The PR adds plotting functionality for AbstractTrees. I've essentially ignored the whole concept of branches (I think of them as property of their subtending nodes) and done everything on nodes. Everything is designed to fit in with the existing syntax of Plots.

One improvement I still want to do is to allow passing things like `line_z` (to color the lines) as `Dict{Node, T}` and have the recipe transform it into Vectors, so the user will  not have to worry about ordering things the right way.

I've also made a `ladderize` function for better plotting to throw in, but I can't get the thing to work. I think it's something to do with the traversal order.

```julia
# Read the tree and load the plotting ocde
using Phylo
using Plots
include("/Users/michael/.julia/dev/Phylo/src/plot.jl")
gr(fmt = :png, lc = :black)
```

There are two basic layouts:
`:dendrogram` (the default)
```julia
passerines = open(t->parsenewick(t, NamedPolytomousTree), "delete/passerines.tree")
plot(passerines, size = (400, 1200), showtips = false)
```
![skaermbillede 2018-09-11 kl 14 35 28](https://user-images.githubusercontent.com/8429802/45362553-6f041480-b5d5-11e8-8023-111e4a1f6626.png)

and `:fan`

```julia
hummers = open(t->parsenewick(t, NamedPolytomousTree), "delete/hummingbirds.tree")
plot(hummers, treetype = :fan)
```
![skaermbillede 2018-09-11 kl 14 48 39](https://user-images.githubusercontent.com/8429802/45362580-7f1bf400-b5d5-11e8-8263-d877b6e09f9b.png)

You can color the branches after a variable. So let us evolve a trait on the
hummingbird tree according to Brownian motion. I use a depth-first recursive mapping
function I've also put in the code
```julia
evolve(tree) = map_depthfirst((val, node) -> val + randn(), 0., tree, Float64)
trait = evolve(hummers)
plot(hummers, treetype = :fan, line_z = trait, lw = 5, showtips = false, c = :RdYlBu)
```
![skaermbillede 2018-09-11 kl 14 51 48](https://user-images.githubusercontent.com/8429802/45362600-8ba04c80-b5d5-11e8-9197-6476649a1444.png)

Or let's highlight the oscines in the passerine tree
```julia
osc_color = map_depthfirst((val, node) -> node == "Oscines" ? :orange : val, :black, passerines)
plot(passerines, linecolor = osc_color, showtips = false, lw = 2, size = (400, 1200))
```
![skaermbillede 2018-09-11 kl 15 17 13](https://user-images.githubusercontent.com/8429802/45362727-e33eb800-b5d5-11e8-9d05-7186232441f2.png)

It's also got support for markers (that can have different colors and layout as well), and basic support for branch annotations (though this isn't as nice as it should be).
```julia
plot(hummers, lc = :orange, lw = 5, size = (400, 1100), markersize = 4, series_annotations = text.(1:count(!isleaf, nodeiter(tree)), 6, :right, :bottom), msc = :white)
```
![skaermbillede 2018-09-11 kl 15 10 02](https://user-images.githubusercontent.com/8429802/45362748-f05ba700-b5d5-11e8-9783-4267782d1020.png)

Finally, it's already somewhat efficient (but there is plenty of room for avoiding allocations and making it faster still)

```julia
qian = open(t->parsenewick(t, NamedPolytomousTree), "delete/Qian2016.tree") # this takes several minutes
# PolytomousTree{DataFrames.DataFrame,Dict{String,Any}} with 31389 tips, 62776 nodes and 62775 branches.
# Leaf names are Blasia_pusilla, Lunularia_cruciata, Marchantia_polymorpha, Riccia_fluitans, Reboulia_hemisphaerica, ... [31383 omitted] ... and Salvia_aethiopis

@time display(plot(qian, showtips = false, treetype = :fan))
# 1.012017 seconds (3.81 M allocations: 169.401 MiB, 25.17% gc time)
```
![skaermbillede 2018-09-11 kl 15 05 20](https://user-images.githubusercontent.com/8429802/45362753-f6ea1e80-b5d5-11e8-8929-601675ca1ef0.png)


